### PR TITLE
Allow SWA deploy to skip when secrets missing

### DIFF
--- a/.github/workflows/azure-static-web-apps-yellow-cliff-03142c500.yml
+++ b/.github/workflows/azure-static-web-apps-yellow-cliff-03142c500.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_YELLOW_CLIFF_03142C500 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
-          skip_deploy_on_missing_secrets: true
+vvvvvvn  xm                 skip_deploy_on_missing_secrets: true
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig


### PR DESCRIPTION
Adds `skip_deploy_on_missing_secrets: true` to the SWA workflow so Dependabot PRs do not fail when the deployment token is not available.